### PR TITLE
Normalize dataset labels for language detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # Language-Detection-System-Using-Machine-Learning
 A supervised machine learning model is trained using a Kaggle dataset with text samples in 20 languages. TF-IDF vectorization is used to convert text into features, and a Multinomial Naive Bayes classifier predicts the language of user-inputted text.
+
+## Usage
+
+Install the Python dependencies and run the script to train the model and test it interactively:
+
+```bash
+pip install -r requirements.txt
+python language_detection.py
+```
+
+For a simple web UI built with Streamlit run:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+The script automatically loads the dataset from `aaiml_proj/Language Detection.csv` and fixes a few misspelled language names (e.g. `Portugeese` -> `Portuguese`). After training, it prints the accuracy score and waits for your input sentences.

--- a/language_detection.py
+++ b/language_detection.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import make_pipeline
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.naive_bayes import MultinomialNB
+
+
+def load_dataset():
+    """Load dataset relative to repository root."""
+    # Determine path of this script and dataset location
+    repo_root = Path(__file__).resolve().parent
+    csv_path = repo_root / 'aaiml_proj' / 'Language Detection.csv'
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Dataset not found at {csv_path}")
+    df = pd.read_csv(csv_path)
+    return _normalize_labels(df)
+
+
+def _normalize_labels(df: pd.DataFrame) -> pd.DataFrame:
+    """Fix common misspellings in the language labels."""
+    corrections = {
+        "Portugeese": "Portuguese",
+        "Sweedish": "Swedish",
+    }
+    df = df.copy()
+    df["Language"] = df["Language"].replace(corrections)
+    return df
+
+
+def train_model(df):
+    X_train, X_test, y_train, y_test = train_test_split(
+        df['Text'], df['Language'], test_size=0.2, random_state=42
+    )
+    model = make_pipeline(TfidfVectorizer(), MultinomialNB())
+    model.fit(X_train, y_train)
+    score = model.score(X_test, y_test)
+    print(f"Model accuracy: {score:.3f}")
+    return model
+
+
+def interactive_predict(model):
+    while True:
+        try:
+            user_input = input("\nEnter a sentence (or 'exit'): ")
+        except EOFError:
+            break
+        if user_input.lower() == 'exit':
+            break
+        if not user_input.strip():
+            print("Please enter some text.")
+            continue
+        pred = model.predict([user_input])[0]
+        print("Detected Language:", pred)
+
+
+if __name__ == "__main__":
+    data = load_dataset()
+    clf = train_model(data)
+    interactive_predict(clf)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pandas
+scikit-learn
+streamlit
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,19 @@
+import streamlit as st
+from language_detection import load_dataset, train_model
+
+@st.cache_data(show_spinner=False)
+def get_model():
+    data = load_dataset()
+    return train_model(data)
+
+st.title("Language Detection")
+
+text = st.text_area("Enter text", "")
+if st.button("Detect"):
+    if text.strip():
+        model = get_model()
+        pred = model.predict([text])[0]
+        st.write("Detected Language:", pred)
+    else:
+        st.warning("Please enter some text.")
+


### PR DESCRIPTION
## Summary
- fix misspelled language names when loading dataset
- expose dataset loading in the script and update README
- add Streamlit frontend and better input handling

## Testing
- `python -m py_compile language_detection.py streamlit_app.py`
- `streamlit run streamlit_app.py --server.headless true --server.port 8501` *(manual stop)*

------
https://chatgpt.com/codex/tasks/task_e_6876b9c1425c832fbb65b5e99e6db889